### PR TITLE
Link Folder Fix

### DIFF
--- a/data.json
+++ b/data.json
@@ -1,5 +1,8 @@
 {
   "linkPrefix": "-",
   "showFileEnding": false,
+  "linkFolder": false,
+  "embedFile": false,
+  "shortLinks": false,
   "mySetting": "-"
 }

--- a/src/FileEmbeder.tsx
+++ b/src/FileEmbeder.tsx
@@ -7,7 +7,6 @@ import { FileLinkSettings } from "./interfaces";
 export class FileEmbeder {
   attachementFolder: string;
   basePath: string;
-
   settings: FileLinkSettings;
 
   constructor(
@@ -68,32 +67,33 @@ export class FileEmbeder {
     return { path, pathComponents, filename };
   }
 
-  linkFor(file: File, prefix: boolean) {
-    let { path, pathComponents, filename } = this.pathInfo(file);
+  linkFor(file: File, printPrefix: boolean) {
+    let { path, pathComponents, filename: linkName } = this.pathInfo(file);
     let prefixString = "";
 
     if (!this.settings.showFileEnding) {
-      let filenameComponents = filename.split(".");
+      let filenameComponents = linkName.split(".");
       filenameComponents.pop();
-      filename = filenameComponents.join(".");
+      linkName = filenameComponents.join(".");
     }
 
     if (this.settings.linkFolder) {
-      pathComponents.pop();
+      linkName = pathComponents[pathComponents.length - 1]; // .peek()
       path = pathComponents.join("/");
     }
-    if (prefix) {
+
+    if (printPrefix) {
       prefixString = this.settings.linkPrefix;
     }
 
     if (this.settings.shortLinks) {
-      return prefixString + "[" + filename + "](<file:///" + path + ">)\n";
+      return prefixString + "[" + linkName + "](<file:///" + path + ">)\n";
     }
 
     return (
       prefixString +
       "[" +
-      filename +
+      linkName +
       "](file:///" +
       encodeURIComponent(path) +
       ")\n"


### PR DESCRIPTION
This should address #12. I hope this helps!

The user still has to select a file within the folder that they want, but the alternative is a bigger change and would require more investigation. 

The investigation would start with figuring out how to get a "Select a Folder" modal to appear. The closest I got was this: `let dirInput = contentEl.createEl("input", {type: "file", attr: { webkitdirectory: true}});` but it tried to upload all of the files in the selected directory and that's not what we were going for.


